### PR TITLE
Support Google Meet when installed as a standalone application

### DIFF
--- a/src/MeetWrapper.js
+++ b/src/MeetWrapper.js
@@ -61,7 +61,9 @@ class MeetWrapper { // eslint-disable-line
     });
 
     // Watch for room changes
-    if (window.location.pathname === '/') {
+    if (window.location.pathname === "/" ||
+      // The installed PWA version may have this path.
+      window.location.pathname.indexOf("/landing") !== -1) {
       this.#enterLobby();
       return;
     }


### PR DESCRIPTION
When installed as a standalone application, I've observed the path of the Google Meet app (when in the lobby) to be `/landing`, so I'm adjusting the code to reflect that. In my testing, this fixes the issue of the controls not appearing in the lobby. 