### PR TITLE
Swap cc / cc-on with end-call on the Deck Mini

### DIFF
--- a/src/StreamDeckMini.js
+++ b/src/StreamDeckMini.js
@@ -45,11 +45,11 @@ class StreamDeckMini { // eslint-disable-line
 
     // Meeting
     // cam, cam-disabled
-    'cc': 6,
-    'cc-on': 6,
+    'cc': -1,
+    'cc-on': -1,
     'chat': 3,
     'chat-open': 3,
-    'end-call': -1,
+    'end-call': 6,
     'hand': 5,
     'hand-raised': 5,
     // mic, mic-disabled


### PR DESCRIPTION
Currently, cc (on/off) isn't working (for me at least, it's also not loading the button icon). But in any case, having a dedicated button to end a call makes more sense to me.
This change will swap the cc / cc-on with end-call. - see issue #15 