### PR TITLE
Show connect button on /landing

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -27,7 +27,7 @@ const sdConnectButtonID = 'streamDeckHelperConnect';
  * Adds a Connect to StreamDeck button to the page.
  */
 function addConnectButton() {
-  if (window.location.pathname !== '/') {
+  if (window.location.pathname !== '/' && window.location.pathname !== '/landing') {
     return;
   }
   const elem = document.createElement('button');


### PR DESCRIPTION
I don't know when this changed, but i think the homepage moved to /landing a bit ago.